### PR TITLE
Panel id fix

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
     "name": "eggd_optimised_filtering",
-    "title": "Optimised_filtering",
+    "title": "eggd_optimised_filtering",
     "summary": "Adds extra MOI info to VCF & filters on provided bcftools string",
     "dxapi": "1.0.0",
     "version": "1.0.0",

--- a/dxapp.json
+++ b/dxapp.json
@@ -20,7 +20,7 @@
         },
         {
         "name": "panel_string",
-        "label": "panels being tested, comma separated",
+        "label": "panel being tested, or semi-colon separated list of HGNC IDs",
         "class": "string",
         "optional": false
         },

--- a/resources/tests/test_panels.py
+++ b/resources/tests/test_panels.py
@@ -94,18 +94,22 @@ class TestGetPanelIDFromGenePanels():
                 'R104.3_Skeletal dysplasia_P', self.test_panels_dict
             )
 
-    def test_get_panel_id_when_panel_id_is_empty_string(self):
+    def test_get_panel_id_when_panel_id_is_empty_string(self, capsys):
         """
-        Check assertion error is raised if panel ID is empty, i.e. just ''
+        Check expected warning is raised if panel ID is empty, i.e. just ''
         """
-        expected_error = (
-            "The clinical indication R97.1_Thrombophilia_P does not have a "
-            "panel ID found in genepanels"
+        expected_warning = (
+            "WARNING: Panel R97.1_Thrombophilia_P has no PanelApp ID in the "
+            "given genepanels file. No MOI filtering will occur."
         )
-        with pytest.raises(AssertionError, match=expected_error):
-            panels.get_panel_id_from_genepanels(
-                'R97.1_Thrombophilia_P', self.test_panels_dict
-            )
+        panels.get_panel_id_from_genepanels(
+            'R97.1_Thrombophilia_P', self.test_panels_dict
+        )
+        stdout = capsys.readouterr().out
+        assert expected_warning in stdout, (
+            "Warning not raised correctly if panel given which is present"
+            " in genepanels but has no panel ID in this file"
+        )
 
     def test_when_more_than_one_panel_id_exists_plus_empty_string(self):
         """

--- a/resources/tests/test_vcf.py
+++ b/resources/tests/test_vcf.py
@@ -134,7 +134,7 @@ class TestBcftoolsPreProcess():
         +split-vep
         """
         mock_subprocess.side_effect = [
-            Mock(stdout=b'5'), Mock(returncode=0), Mock(stdout=b'14')
+            Mock(stdout=b'14'), Mock(returncode=0), Mock(stdout=b'5')
         ]
 
         with pytest.raises(AssertionError):

--- a/resources/utils/panels.py
+++ b/resources/utils/panels.py
@@ -92,16 +92,17 @@ def get_panel_id_from_genepanels(panel_string, genepanels_dict):
         )
         # Get the only panel ID value in the list
         panel_id = panel_ids[0]
-        assert panel_id, (
-            f"The clinical indication {panel_string} does not have a panel ID "
-            "found in genepanels"
-        )
+        if not panel_id:
+            print(
+                f"WARNING: Panel {panel_string} has no PanelApp ID in the "
+                "given genepanels file. No MOI filtering will occur."
+            )
 
     else:
         print(
             f"WARNING: The panel string given {panel_string} was not found in "
             "the genepanels file. This is expected if only HGNCs have been "
-            "entered, but no MOI-specific filtering will be performed"
+            "entered, but no MOI-specific filtering will be performed."
         )
 
     return panel_id

--- a/resources/utils/vcf.py
+++ b/resources/utils/vcf.py
@@ -111,7 +111,7 @@ def bcftools_pre_process(input_vcf) -> str:
         f"Total lines after splitting: {post_split}"
     )
 
-    assert post_split >= pre_split, (
+    assert int(post_split) >= int(pre_split), (
         "Count of variants following bcftools +split-vep is fewer than the "
         "input VCF"
     )


### PR DESCRIPTION
Panels with no PanelApp ID in genepanels now give a warning (no MOI) rather than failing.
Panel_string label now mentions the correct separator.
Title conforms to eggd standard.
Pre/post split counts now compared as ints rather than strings.

Fixes #13, #14, and #15

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_optimised_filtering/16)
<!-- Reviewable:end -->
